### PR TITLE
Exception raised from circuited function should be propagated

### DIFF
--- a/pycircuitbreaker/pycircuitbreaker.py
+++ b/pycircuitbreaker/pycircuitbreaker.py
@@ -60,11 +60,11 @@ class CircuitBreaker:
         result = None
 
         try:
-            result = func(*args, *kwargs)
+            result = func(*args, **kwargs)
         except Exception as ex:
             if not self._exception_whitelisted(ex) and self._exception_blacklisted(ex):
                 self._handle_error(ex)
-                raise
+            raise
 
         if self._detect_error is not None and self._detect_error(result):
             self._handle_error(result)

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -103,7 +103,8 @@ def test_exception_whitelist(error_func):
     breaker = CircuitBreaker(
         error_threshold=1, exception_whitelist=[IOError], recovery_timeout=1
     )
-    breaker.call(error_func)
+    with pytest.raises(IOError):
+        breaker.call(error_func)
 
     assert breaker.state == CircuitBreakerState.CLOSED
 
@@ -112,7 +113,8 @@ def test_exception_whitelist_supports_inheritance(error_func):
     breaker = CircuitBreaker(
         error_threshold=1, exception_whitelist=[Exception], recovery_timeout=1
     )
-    breaker.call(error_func)
+    with pytest.raises(IOError):
+        breaker.call(error_func)
 
     assert breaker.state == CircuitBreakerState.CLOSED
 
@@ -122,7 +124,8 @@ def test_exception_blacklist_filters_errors(error_func):
     breaker = CircuitBreaker(
         error_threshold=1, exception_blacklist=[ValueError], recovery_timeout=1
     )
-    breaker.call(error_func)
+    with pytest.raises(IOError):
+        breaker.call(error_func)
 
     assert breaker.state == CircuitBreakerState.CLOSED
 


### PR DESCRIPTION
Hello,

Thanks for this amazing library that looks the most feature complete when looking for a circuit breaker in python.

I tried to use it in my project and noticed that when an exception is raised from a circuited function, it is not propagated to the caller.

I also used this PR to fix a bad behavior when using named arguments in circuited functions.



